### PR TITLE
add --net=host and mount GOPATH

### DIFF
--- a/files/circle.yml
+++ b/files/circle.yml
@@ -15,7 +15,7 @@ test:
       --tty
       --interactive
       --name go
-      --net=host
+      --net host
       --volume /var/run/docker.sock:/run/docker.sock
       --volume ${GOPATH%%:*}/src:/go/src
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}

--- a/files/circle.yml
+++ b/files/circle.yml
@@ -15,7 +15,9 @@ test:
       --tty
       --interactive
       --name go
+      --net=host
       --volume /var/run/docker.sock:/run/docker.sock
+      --volume ${GOPATH%%:*}/src:/go/src
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest


### PR DESCRIPTION
@segmentio/infra 

There are two improvements that come with this pull request:
- `--net=host` this is necessary to allow the container to communicate with the containers that docker-compose brings up, all our tests expect to be able to connect to these containers on localhost, which is not the case by default with `--net=bridge`.

- Exposes the host's GOPATH to the container so Circle's cache can be used to speed up builds and local builds can also run faster.
