### PR TITLE
Revert "Move teardown"

### DIFF
--- a/files/Makefile.golang
+++ b/files/Makefile.golang
@@ -62,14 +62,12 @@ get: git.submodule.update govendor.sync
 vet:
 	-@$(call do,$(go.vet))
 
-test: get
-	@$(MAKE) -f /usr/src/Makefile.golang --no-print-directory test.setup
+test: get test.setup
 	@function teardown { $(MAKE) -f /usr/src/Makefile.golang --no-print-directory test.teardown; }; \
 	trap teardown EXIT; \
 	$(call do,$(go.test))
 
-bench: get
-	@$(MAKE) -f /usr/src/Makefile.golang --no-print-directory test.setup
+bench: get test.setup
 	@function teardown { $(MAKE) -f /usr/src/Makefile.golang --no-print-directory test.teardown; }; \
 	trap teardown EXIT; \
 	@$(call do,$(go.bench))
@@ -97,7 +95,7 @@ docker.compose.up: docker.login
 	@$(call do,docker-compose up -d)
 
 docker.compose.down:
-	@$(call do,docker-compose down --remove-orphans)
+	@$(call do,docker-compose down)
 
 # When a .gitmodules file exists we pull all git submodules recursively to make
 # sure we have all the dependencies we need to run tests and build.


### PR DESCRIPTION
Reverts segmentio/golang-image#14 (blocking releases, branch has been restored for follow-up by @calvinfo and @achille-roussel.